### PR TITLE
Fix for latest CPAN Testers fail cases.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,5 +16,4 @@ author_tests 'xt';
 test_requires 'Test::More' => '0.96';
 test_requires 'Test::Most';
 auto_set_repository;
-auto_include;
 WriteAll;


### PR DESCRIPTION
- Removing auto_include from Makefile.PL.

My reasoning for this change is that there are some issues with inc/ packaged versions of `Test::More` and installed `Test::Builder`:

https://github.com/Test-More/test-more/issues/479
https://github.com/sekia/Algorithm-LibLinear/issues/2

This is the same approach that was used to fix `Algorithm::LibLinear` tests:

https://github.com/sekia/Algorithm-LibLinear/commit/0297106